### PR TITLE
Show ships on the post-game screen

### DIFF
--- a/src/Gamehelpers/boardLoader.js
+++ b/src/Gamehelpers/boardLoader.js
@@ -8,7 +8,7 @@ function boardLoader(cb, pcPlayer){
         const cell = document.createElement('img');
         cell.classList.add('cell');
         cell.src = water;
-        cell.id = `cell-${pcPlayer ? '2' : ""}${i}`;
+        cell.id = `cell-${pcPlayer ? 'pc-' : ""}${i}`;
         board.appendChild(cell);
         if(cb){
         cell.addEventListener('click', function func(e){

--- a/src/Gamehelpers/init.js
+++ b/src/Gamehelpers/init.js
@@ -181,7 +181,7 @@ function init(human, gameControllerCallback) {
                 human.ships[shipsPlaced].location.map(
                     (index) => arr[index].src=water)
                 //Load ship icon in correct place (maybe in boardLoader?)
-                human.ships[shipsPlaced].loadShipIcon();
+                human.ships[shipsPlaced].loadShipIcon('.board');
                 shipsPlaced++;
                 placementController()
             }

--- a/src/Gamehelpers/postgame.js
+++ b/src/Gamehelpers/postgame.js
@@ -4,17 +4,22 @@ const postgame = (result, restart) => {
     const resultDisplay = document.querySelector('.result-display')
     resultDisplay.classList.remove('hide');
     result === 'win' ? resultDisplay.innerHTML = "YOU WON!" : resultDisplay.innerHTML = 'YOU LOST!';
-    
     const restartButton = document.querySelector('.game-start')
-    const boardholder = document.querySelector('.board-holder')
-    boardholder.classList.add('hide');
-    boardholder.removeChild(boardholder.children[1]);
-    const boardholder2 = document.querySelector('.board2')
-    boardholder2.removeChild(boardholder2.children[1])
+    const boardholderInfo = document.querySelector('.board-holder-info')
+    const boardholderInfo2 = document.querySelector('.board2 .board-holder-info');
+    boardholderInfo.classList.add('hide');
+    boardholderInfo2.classList.add('hide');
 
-    boardholder2.classList.remove('show');
     restartButton.classList.remove('hide');
     restartButton.addEventListener('click', function reset(){
+        boardholderInfo.classList.remove('hide');
+        boardholderInfo2.classList.remove('hide');
+        const boardholder = document.querySelector('.board-holder');
+        const boardholder2 = document.querySelector('.board2');
+        boardholder.removeChild(boardholder.children[1]);
+        boardholder2.removeChild(boardholder2.children[1]);
+        boardholder.classList.remove('show');
+        boardholder2.classList.remove('show');
         restartButton.classList.add('hide');
         restart();
         restartButton.removeEventListener('click', reset);

--- a/src/modules/gameController.js
+++ b/src/modules/gameController.js
@@ -14,6 +14,8 @@ let pcAI = AI(computerPlayer);
 const gameController = () => {
     console.log('GAME CONTROLLER!!!')
 
+    let isGameCompleted = false;
+
 
     window.addEventListener('resize', resizeListener)
     startButton(start);
@@ -25,12 +27,7 @@ const gameController = () => {
 
     }
 
-
-
-
-}
-
-//Called after init is finished
+    //Called after init is finished
 function postInitCallback(){
     //Randomly Place AI Ships
     pcAI.placeShips(computerPlayer);
@@ -44,6 +41,7 @@ function postInitCallback(){
 
         const restart = () => {
             console.log('RESTARTO!!!')
+            isGameCompleted = false;
             humanPlayer = new player();
             computerPlayer = new player();
             pcAI = AI(computerPlayer);
@@ -51,18 +49,30 @@ function postInitCallback(){
         }
 
         function postGameCallback(result){
-        console.log('games over')
+        console.log('games over');
+        isGameCompleted = true;
+        computerPlayer.ships.map( (ship) => {
+            ship.loadShipIcon('.pc-board');
+        });
         postgame(result, restart);
     }
 }
-    //Listens for window resize and adjusts ship placement accordingly
-    function resizeListener(){
-
+    // Listens for window resize and adjusts ship placement accordingly
+    function resizeListener() {
         humanPlayer.ships.map( (ship) => {
-            ship.loadShipIcon() 
-
+            ship.loadShipIcon('.board');
         });
+
+        if (isGameCompleted) {
+            computerPlayer.ships.map( (ship) => {
+                ship.loadShipIcon('.pc-board');
+            });
+        }
     }
 
 
+
+
+
+}
 export default gameController;

--- a/src/modules/ship.js
+++ b/src/modules/ship.js
@@ -42,17 +42,19 @@ class ship{
         }
     }
     // Load ship icons into HTML and place accordingly according to board (query selector??)
-    loadShipIcon(){
+    loadShipIcon(boardSelector){
+        const pcPlayer = boardSelector == '.pc-board';
+        const iconId = `${this.name}-${pcPlayer ? 'pc-' : ""}icon`;
 
         if( this.location.length === 0 ) return;
         const location = this.location[0];
-        const cell = document.querySelector(`#cell-${location}`)
+        const cell = document.querySelector(`#cell-${pcPlayer ? 'pc-' : ""}${location}`)
         const cord = (cell.getBoundingClientRect())
         //For calling upon resizing a window.. if it exists, modify exisiting ship, else create a new one
-        const iconImg = (!document.querySelector(`#${this.name}-icon`)) ? document.createElement('img') : (document.querySelector(`#${this.name}-icon`));
+        const iconImg = (!document.querySelector(`#${iconId}`)) ? document.createElement('img') : (document.querySelector(`#${iconId}`));
         iconImg.src = this.icon;
         iconImg.classList.add('ship-icon')
-        iconImg.id = `${this.name}-icon`
+        iconImg.id = iconId;
         iconImg.style.position = 'absolute';
         // If Y Axis change left attr, rotate
         if(!this.xAxis) {
@@ -62,8 +64,8 @@ class ship{
         
         iconImg.style.top = `${cord.top}px`;
         
-        if (!document.querySelector(`#${this.name}-icon`)){
-            const boardDiv = document.querySelector('.board')
+        if (!document.querySelector(`#${iconId}`)) {
+            const boardDiv = document.querySelector(boardSelector)
             
             boardDiv.append(iconImg)
         }

--- a/src/modules/ship.js
+++ b/src/modules/ship.js
@@ -42,18 +42,24 @@ class ship{
         }
     }
     // Load ship icons into HTML and place accordingly according to board (query selector??)
-    loadShipIcon(){
+    loadShipIcon(boardSelector){
+        const pcPlayer = boardSelector == '.pc-board';
+        const iconId = `${this.name}-${pcPlayer ? 'pc-' : ""}icon`;
 
         if( this.location.length === 0 ) return;
         const location = this.location[0];
-        const cell = document.querySelector(`#cell-${location}`)
+        const cell = document.querySelector(`#cell-${pcPlayer ? 'pc-' : ""}${location}`)
         const cord = (cell.getBoundingClientRect())
         //For calling upon resizing a window.. if it exists, modify exisiting ship, else create a new one
-        const iconImg = (!document.querySelector(`#${this.name}-icon`)) ? document.createElement('img') : (document.querySelector(`#${this.name}-icon`));
+        const iconImg = (!document.querySelector(`#${iconId}`)) ? document.createElement('img') : (document.querySelector(`#${iconId}`));
         iconImg.src = this.icon;
         iconImg.classList.add('ship-icon')
-        iconImg.id = `${this.name}-icon`
+        iconImg.id = iconId;
         iconImg.style.position = 'absolute';
+        // Add red-filter to pcPlayer ships
+        if (pcPlayer) {
+            iconImg.classList.add('red-filter');
+        }
         // If Y Axis change left attr, rotate
         if(!this.xAxis) {
             iconImg.style.transform = "rotate(90deg)"
@@ -62,8 +68,8 @@ class ship{
         
         iconImg.style.top = `${cord.top}px`;
         
-        if (!document.querySelector(`#${this.name}-icon`)){
-            const boardDiv = document.querySelector('.board')
+        if (!document.querySelector(`#${iconId}`)) {
+            const boardDiv = document.querySelector(boardSelector)
             
             boardDiv.append(iconImg)
         }

--- a/src/modules/startGameplay.js
+++ b/src/modules/startGameplay.js
@@ -68,7 +68,7 @@ const startGameplay= (gameEndCallback, humanPlayer, computerPlayer) => {
     const fireShotListener = (e) => {
         const pcBoard = document.querySelector('.pc-board')
         pcBoard.classList.add('no-pointer-events')
-        const div = document.querySelector(`.cell-2${e.target.id}`)
+
         interpretAttack(e.target);
             clearInfo();
             setInfo();
@@ -103,7 +103,7 @@ const startGameplay= (gameEndCallback, humanPlayer, computerPlayer) => {
     const interpretAttack = (cell) => {
 
         
-        const cellNum = cell.id.slice(6)
+        const cellNum = cell.id.slice(8); // breh ...
 
         computerPlayer.gameboard.fireShot(cellNum)
         //If player hits pc ship

--- a/src/styles.css
+++ b/src/styles.css
@@ -44,7 +44,7 @@
     text-align: center;
     z-index: 5;
     height: 50px;
-    width: 200px;
+    width: 175px;
     position: absolute;
     left: 50%;
     top: 50%;
@@ -56,6 +56,7 @@
     border-color: white;
     overflow: hidden;
     padding-top: 5px;
+    cursor:pointer;
 
 
     

--- a/src/styles.css
+++ b/src/styles.css
@@ -44,7 +44,7 @@
     text-align: center;
     z-index: 5;
     height: 50px;
-    width: 200px;
+    width: 175px;
     position: absolute;
     left: 50%;
     top: 50%;
@@ -56,6 +56,7 @@
     border-color: white;
     overflow: hidden;
     padding-top: 5px;
+    cursor:pointer;
 
 
     
@@ -231,7 +232,7 @@
 }
 
 .red-filter{
-    filter: invert(23%) sepia(98%) saturate(4757%) hue-rotate(357deg) brightness(88%) contrast(128%);
+    filter: invert(23%) sepia(98%) saturate(4757%) hue-rotate(357deg) brightness(60%) contrast(128%);
 }
 .missed-attack{
     color: blue;


### PR DESCRIPTION
- Changed the ID prefix for pc-board cells to "pc" instead of "2". This fixes a bug that caused some cells between the cpu board and the player board to have the same ID for indices greater than 19.

- Updated loadShipIcon to take a boardSelector parameter which allows you to choose which board to load the ship icons onto.

- Updated postgame screen to leave the boards up and display the hidden boat positions of the cpu player.